### PR TITLE
Create request-video-archive-to-NAS

### DIFF
--- a/request-video-archive-to-NAS
+++ b/request-video-archive-to-NAS
@@ -1,0 +1,24 @@
+//Hi team, I found a proxy/api in unifi-protect to archive the recording to the NAS (which I already configured in webUI) and automatically convert to mp4. 
+//I discovered it is working with max 1h intervals to process the files. 
+
+//I would like to ask you to implement such option to your package, as my use case is:
+//motion detection finished (recording of motion is finished) -> send the recording to the NAS archive ... 
+//ideally would be to use AWS-CLI to upload to AWS, but it is not natively supported, so I am using NAS in between
+
+//cheers! and let me know if I can help you with anything more!
+
+POST https://NVR-IP/proxy/protect/api/cloud-provider/video-archive
+
+BODY
+{
+  "start": 1726617600000,
+  "end": 1726621200000,
+  "filename": "CameraName DateFrom, TimeFrom - DateTo, TimeTo.mp4",
+  "lens": 0,
+  "destination": "NAS",
+  "cameraId": "666a66a666666a66a6666666",
+  "type": "rotating",
+  "channel": 0,
+  "sharedDrive": "DestinationFolder",
+  "host": "NAS-IP"
+}


### PR DESCRIPTION
Hi team,

I’ve been working with UniFi Protect and discovered a proxy/API that allows archiving recordings to a NAS (already configured via the web UI) and automatically converting them to MP4. This works with up to 1-hour intervals for processing files.

I’d like to propose adding this feature to your package. My use case is:
1. Motion detection event finishes.
2. The recorded footage is automatically sent to the NAS archive.
Ideally, I’d prefer to use AWS-CLI for uploading to AWS, but since it's not natively supported, I'm using a NAS as an intermediary.

If there's anything more I can do to assist with this or provide further insights, feel free to reach out!

Cheers!

POST https://NVR-IP/proxy/protect/api/cloud-provider/video-archive

BODY
{
  "start": 1726617600000,
  "end": 1726621200000,
  "filename": "CameraName DateFrom, TimeFrom - DateTo, TimeTo.mp4",
  "lens": 0,
  "destination": "NAS",
  "cameraId": "666a66a666666a66a6666666",
  "type": "rotating",
  "channel": 0,
  "sharedDrive": "DestinationFolder",
  "host": "NAS-IP"
}