### PR TITLE
Add PTZ Preset and PTZ Position Settings interfaces

### DIFF
--- a/src/protect-types.ts
+++ b/src/protect-types.ts
@@ -1167,7 +1167,13 @@ export type ProtectCameraLcdMessageConfig = ProtectCameraLcdMessageConfigInterfa
 export type ProtectCameraLcdMessagePayload = DeepPartial<ProtectCameraLcdMessageConfigInterface>;
 
 /** @see {@link ProtectCameraPtzPresetInterface} */
+export type ProtectCameraPtzPresetConfig = DeepPartial<ProtectCameraPtzPresetInterface>;
+
+/** @see {@link ProtectCameraPtzPresetInterface} */
 export type ProtectCameraPtzPresetPayload = DeepPartial<ProtectCameraPtzPresetInterface>;
+
+/** @see {@link ProtectCameraPtzPositionSettingsInterface} */
+export type ProtectCameraPtzPositionSettingsConfig = DeepPartial<ProtectCameraPtzPositionSettingsInterface>;
 
 /** @see {@link ProtectCameraPtzPositionSettingsInterface} */
 export type ProtectCameraPtzPositionSettingsPayload = DeepPartial<ProtectCameraPtzPositionSettingsInterface>;

--- a/src/protect-types.ts
+++ b/src/protect-types.ts
@@ -615,6 +615,31 @@ export interface ProtectCameraLcdMessageConfigInterface {
 }
 
 /**
+ * A semi-complete description of the UniFi Protect PTZ Preset JSON.
+ */
+export interface ProtectCameraPtzPresetInterface {
+
+  id: string,
+  camera: string,
+  name: string,
+  slot: number,
+  ptz: ProtectCameraPtzPositionSettingsInterface,
+  snapshot: string
+}
+
+/**
+ * A semi-complete description of the UniFi Protect PTZ Position Settings JSON.
+ */
+export interface ProtectCameraPtzPositionSettingsInterface {
+
+  pan: number,
+  tilt: number,
+  zoom: number,
+  focus: number
+}
+
+
+/**
  * A semi-complete description of the UniFi Protect chime JSON.
  */
 export interface ProtectChimeConfigInterface {
@@ -1140,6 +1165,12 @@ export type ProtectCameraLcdMessageConfig = ProtectCameraLcdMessageConfigInterfa
 
 /** @see {@link ProtectCameraLcdMessageConfigInterface} */
 export type ProtectCameraLcdMessagePayload = DeepPartial<ProtectCameraLcdMessageConfigInterface>;
+
+/** @see {@link ProtectCameraPtzPresetInterface} */
+export type ProtectCameraPtzPresetPayload = DeepPartial<ProtectCameraPtzPresetInterface>;
+
+/** @see {@link ProtectCameraPtzPositionSettingsInterface} */
+export type ProtectCameraPtzPositionSettingsPayload = DeepPartial<ProtectCameraPtzPositionSettingsInterface>;
 
 /** @see {@link ProtectChimeConfigInterface} */
 export type ProtectChimeConfig = ProtectChimeConfigInterface;


### PR DESCRIPTION
Endpoint `https://{{NVR_IP}}/proxy/protect/api/cameras/{{CAMERA_ID}}/ptz/preset` provides the following json

```
[
    {
        "id": "6740ce9c02c8f603e406e4a3",
        "camera": "{{CAMERA_ID}}",
        "name": "Side Yard",
        "slot": 0,
        "ptz": {
            "pan": 18202,
            "tilt": 15795,
            "zoom": 0,
            "focus": 34
        },
        "snapshot": "/cameras/{{CAMERA_ID}}/ptz/snapshot/0?hash=ad677904b1f2fc8b3516de79f7b7ccd5"
    },
    {
        "id": "6740cec20142f603e406e4a6",
        "camera": "{{CAMERA_ID}}",
        "name": "Side Yard 2",
        "slot": 2,
        "ptz": {
            "pan": 25436,
            "tilt": 15946,
            "zoom": 0,
            "focus": 36
        },
        "snapshot": "/cameras/{{CAMERA_ID}}/ptz/snapshot/2?hash=cbba9856924482c8cfd0e903bb000be9"
    },
    {
        "id": "6740cf140046f603e406e4b4",
        "camera": "{{CAMERA_ID}}",
        "name": "Grass Only",
        "slot": 1,
        "ptz": {
            "pan": 17297,
            "tilt": 12410,
            "zoom": 0,
            "focus": 44
        },
        "snapshot": "/cameras/{{CAMERA_ID}}/ptz/snapshot/1?hash=8cf57d39b9fe11dfe9ff4068299a8328"
    }
]
```

We do not have JSON interfaces for this new endpoint to be consumed in [This feature I am implementing into HBUP](https://github.com/hjdhjd/homebridge-unifi-protect/pull/1149)

Clean ESLint:
<img width="1017" alt="Screenshot 2024-11-28 at 4 18 39 PM" src="https://github.com/user-attachments/assets/80175424-eace-4366-8b40-3e6500a93b10">
