### PR TITLE
feat: allow overriding timeout for individual requests

### DIFF
--- a/docs/ProtectApi.md
+++ b/docs/ProtectApi.md
@@ -272,8 +272,9 @@ Valid API endpoints are `livestream` and `talkback`.
 ```ts
 retrieve(
    url, 
-   options, 
-logErrors): Promise<Nullable<Response>>
+   options,
+   logErrors,
+overrideTimeout): Promise<Nullable<Response>>
 ```
 
 Execute an HTTP fetch request to the Protect controller.
@@ -285,6 +286,7 @@ Execute an HTTP fetch request to the Protect controller.
 | `url` | `string` | `undefined` | Complete URL to execute **without** any additional parameters you want to pass (e.g. https://unvr.local/proxy/protect/cameras/someid/snapshot). |
 | `options` | `RequestOptions` | `...` | Parameters to pass on for the endpoint request. |
 | `logErrors` | `boolean` | `true` | Log errors that aren't already accounted for and handled, rather than failing silently. Defaults to `true`. |
+| `overrideTimeout` | `number` | `undefined` | Override the default timeout for the request (useful for AI-Key analyzer requests). Defaults to the global timeout value. |
 
 ###### Returns
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unifi-protect",
-  "version": "4.20.3",
+  "version": "4.20.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "unifi-protect",
-      "version": "4.20.3",
+      "version": "4.20.4",
       "license": "ISC",
       "dependencies": {
         "@adobe/fetch": "4.1.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unifi-protect",
   "type": "module",
-  "version": "4.20.3",
+  "version": "4.20.4",
   "displayName": "UniFi Protect API",
   "description": "A complete implementation of the UniFi Protect API.",
   "author": {

--- a/src/protect-api.ts
+++ b/src/protect-api.ts
@@ -913,9 +913,10 @@ export class ProtectApi extends EventEmitter {
   /**
    * Execute an HTTP fetch request to the Protect controller.
    *
-   * @param url       - Complete URL to execute **without** any additional parameters you want to pass (e.g. https://unvr.local/proxy/protect/cameras/someid/snapshot).
-   * @param options   - Parameters to pass on for the endpoint request.
-   * @param logErrors - Log errors that aren't already accounted for and handled, rather than failing silently. Defaults to `true`.
+   * @param url             - Complete URL to execute **without** any additional parameters you want to pass
+   *                          (e.g. https://unvr.local/proxy/protect/cameras/someid/snapshot).
+   * @param options         - Parameters to pass on for the endpoint request.
+   * @param logErrors       - Log errors that aren't already accounted for and handled, rather than failing silently. Defaults to `true`.
    * @param overrideTimeout - Override the default timeout for the request (useful for AI-Key analyzer requests). Defaults to the global timeout value.
    *
    * @returns Returns a promise that will resolve to a Response object successful, and `null` otherwise.


### PR DESCRIPTION
Hello,
I've recently wanted to do a few tests with the new `/proxy/protect/api/aiprocessors/vlm/analyze` endpoint; however, it usually takes more than 5 seconds for the AI-Key to process the event.

That's why I thought it might be a good idea to allow overriding the value of the timeout signal to allow a larger timeout for certain requests.